### PR TITLE
Remove ouroboros package from meta.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-ouroboros-green.svg)](https://anaconda.org/conda-forge/ouroboros) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ouroboros.svg)](https://anaconda.org/conda-forge/ouroboros) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ouroboros.svg)](https://anaconda.org/conda-forge/ouroboros) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ouroboros.svg)](https://anaconda.org/conda-forge/ouroboros) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ouroboros--gis-green.svg)](https://anaconda.org/conda-forge/ouroboros-gis) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ouroboros-gis.svg)](https://anaconda.org/conda-forge/ouroboros-gis) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ouroboros-gis.svg)](https://anaconda.org/conda-forge/ouroboros-gis) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ouroboros-gis.svg)](https://anaconda.org/conda-forge/ouroboros-gis) |
 
 Installing ouroboros-gis
@@ -40,41 +39,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `ouroboros, ouroboros-gis` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `ouroboros-gis` can be installed with `conda`:
 
 ```
-conda install ouroboros ouroboros-gis
-```
-
-or with `mamba`:
-
-```
-mamba install ouroboros ouroboros-gis
-```
-
-It is possible to list all of the versions of `ouroboros` available on your platform with `conda`:
-
-```
-conda search ouroboros --channel conda-forge
+conda install ouroboros-gis
 ```
 
 or with `mamba`:
 
 ```
-mamba search ouroboros --channel conda-forge
+mamba install ouroboros-gis
+```
+
+It is possible to list all of the versions of `ouroboros-gis` available on your platform with `conda`:
+
+```
+conda search ouroboros-gis --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search ouroboros-gis --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search ouroboros --channel conda-forge
+mamba repoquery search ouroboros-gis --channel conda-forge
 
-# List packages depending on `ouroboros`:
-mamba repoquery whoneeds ouroboros --channel conda-forge
+# List packages depending on `ouroboros-gis`:
+mamba repoquery whoneeds ouroboros-gis --channel conda-forge
 
-# List dependencies of `ouroboros`:
-mamba repoquery depends ouroboros --channel conda-forge
+# List dependencies of `ouroboros-gis`:
+mamba repoquery depends ouroboros-gis --channel conda-forge
 ```
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,21 +46,6 @@ outputs:
         - python {{ python_min }}
         - pip
 
-  - name: ouroboros
-    build:
-      noarch: python
-    requirements:
-      host:
-        - python {{ python_min }}
-      run:
-        - python >={{ python_min }}
-        - {{ pin_subpackage('ouroboros-gis', max_pin="x.x.x") }}
-    test:
-      requires:
-        - python {{ python_min }}
-      imports:
-        - ouroboros
-
 about:
   home: https://github.com/corbel-spatial/ouroboros
   summary: Pythonic use of GeoDatabases

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: f65d3ddf0a23bd5bbca1ed31095b34482cf52cc601eba5f58d892c72c4cdcb46
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: {{ name }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

@conda-forge/core Unfortunately I'd like to request removal of the `ouroboros` (not `ouroboros-gis`) packages from conda-forge. I was in the process of acquiring `ouroboros` on PyPI but I was preempted by another project (https://github.com/pypi/support/issues/7781). In the interest of keeping parity between conda-forge and PyPI, what is the best course of action here?